### PR TITLE
Add a requirements.txt file for Heroku

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Do not use this file to install requirements for development.
+# Install requirements for local development with:
+# pip install -r requirements/local.txt
+
+# Requirements needed by Heroku for deployment
+-r requirements/deployment.txt


### PR DESCRIPTION
Apparently the default heroku/python buildpack requires a requirements.txt or setup.py file to determine requirements. Adding a requirements.txt to alias the requirements/deployment.txt requirements file.
