### PR TITLE
Downgrade django-revproxy

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,7 +1,7 @@
 dj-database-url==0.3.0
 dj-static==0.0.6
 Django==1.9.1
-django-revproxy==0.9.9
+django-revproxy==0.9.8
 invoke==0.11.1
 Jinja2==2.8
 libsass==0.10.0


### PR DESCRIPTION
There's a bug in django-revproxy that's visible in Python 3 environments. Downgrading for now.
