### PR TITLE
Add missing waitress requirement to deployment requirements

### DIFF
--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -1,2 +1,3 @@
 -r common.txt
 psycopg2==2.6.1
+waitress==0.8.10


### PR DESCRIPTION
Looks like I left out waitress in the deployment requirements when I broke up the requirements file into environment-specific requirements. Adding now.
