### PR TITLE
Add code of conduct redirect

### DIFF
--- a/pythonsd/tests.py
+++ b/pythonsd/tests.py
@@ -19,6 +19,25 @@ import tasks
 from . import jinja2, static_files, wsgi
 
 
+class TestRedirectViews(test.TestCase):
+    """Ensure project redirects function correctly."""
+
+    def test_home_redirect(self):
+        """The root path '/' should redirect to '/index.html'
+        in order to work with the reverse proxy.
+        """
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/index.html')
+
+    def test_coc_redirect(self):
+        """The shortcut '/coc' path should redirect to
+        the code of conduct page."""
+        response = self.client.get('/coc')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/pages/code-of-conduct.html')
+
+
 @mock.patch('revproxy.views.HTTP_POOLS.urlopen', return_value=mock.MagicMock(status=200))
 class TestProxyViews(test.TestCase):
     """Any path not served by this Django app should proxy to the static site."""

--- a/pythonsd/urls.py
+++ b/pythonsd/urls.py
@@ -7,6 +7,7 @@ from revproxy.views import ProxyView
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
 
-    url(r'^$', generic.RedirectView.as_view(url='index.html', permanent=False), name='home'),
-    url(r'^(?P<path>.*)$', ProxyView.as_view(upstream=settings.PYTHONSD_STATIC_SITE))
+    url(r'^$', generic.RedirectView.as_view(url='/index.html', permanent=False), name='home'),
+    url(r'coc/?$', generic.RedirectView.as_view(url='/pages/code-of-conduct.html')),
+    url(r'^(?P<path>.*)$', ProxyView.as_view(upstream=settings.PYTHONSD_STATIC_SITE)),
 ]


### PR DESCRIPTION
This allows us to guide people to http://pythonsd.org/coc in order to get to our code of conduct.
