### PR TITLE
Allow cross-origin requests on the meetup widget

### DIFF
--- a/pythonsd/tests/__init__.py
+++ b/pythonsd/tests/__init__.py
@@ -83,6 +83,19 @@ class TestMeetupWidget(test.TestCase):
         self.assertContains(response, 'UCSD Geisel Library')
         self.assertContains(response, 'Qualcomm Building Q')
 
+    def test_cors(self):
+        with mock.patch('pythonsd.views.requests.get') as mock_get:
+            mock_get.return_value.ok = True
+            mock_get.return_value.json.return_value = self.api_response
+            response = self.client.get('/meetup-widget.html')
+        self.assertEqual(response['Access-Control-Allow-Origin'], '*')
+
+        with mock.patch('pythonsd.views.requests.get') as mock_get:
+            mock_get.return_value.ok = True
+            mock_get.return_value.json.return_value = self.api_response
+            response = self.client.get('/meetup-widget.json')
+        self.assertEqual(response['Access-Control-Allow-Origin'], '*')
+
     def test_json_widget(self):
         with mock.patch('pythonsd.views.requests.get') as mock_get:
             mock_get.return_value.ok = True

--- a/pythonsd/views.py
+++ b/pythonsd/views.py
@@ -29,9 +29,13 @@ class MeetupWidget(TemplateView):
         format = kwargs.get('format')
 
         if format == 'json':
-            return JsonResponse(self.get_upcoming_events(), safe=False)
+            response = JsonResponse(self.get_upcoming_events(), safe=False)
+        else:
+            response = super().get(self, request, *args, **kwargs)
 
-        return super().get(self, request, *args, **kwargs)
+        response['Access-Control-Allow-Origin'] = '*'
+
+        return response
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Allow [cross-origin requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) on the meetup widget. This will allow the  [pythonsd.org site](https://github.com/pythonsd/pythonsd.org) to request the meetup site (especially in dev).