### PR TITLE
Tweak production Django settings

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -12,12 +12,12 @@ import os
 import dj_database_url
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..')
+BASE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../..")
 
 
-PYTHONSD_STATIC_SITE = 'https://pythonsd.github.io/pythonsd.org/'
+PYTHONSD_STATIC_SITE = "https://pythonsd.github.io/pythonsd.org/"
 
-ADMIN_URL = 'admin'
+ADMIN_URL = "admin"
 
 
 # Quick-start development settings - unsuitable for production
@@ -25,85 +25,79 @@ ADMIN_URL = 'admin'
 
 # SECURITY WARNING: keep the secret key used in production secret!
 # SECURITY WARNING: don't run with debug turned on in production!
-SECRET_KEY = 'MOCK SECRET'
+SECRET_KEY = "MOCK SECRET"
 DEBUG = True
 
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 
-INTERNAL_IPS = [
-    '127.0.0.1',
-]
+INTERNAL_IPS = ["127.0.0.1"]
 
 
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'pythonsd',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "pythonsd",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'config.urls'
+ROOT_URLCONF = "config.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-            ],
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ]
         },
     },
     {
-        'BACKEND': 'django.template.backends.jinja2.Jinja2',
-        'DIRS': [os.path.join(BASE_DIR, 'pythonsd', 'jinja2')],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'environment': 'pythonsd.jinja2.environment',
-        },
+        "BACKEND": "django.template.backends.jinja2.Jinja2",
+        "DIRS": [os.path.join(BASE_DIR, "pythonsd", "jinja2")],
+        "APP_DIRS": True,
+        "OPTIONS": {"environment": "pythonsd.jinja2.environment"},
     },
 ]
 
-WSGI_APPLICATION = 'config.wsgi.application'
+WSGI_APPLICATION = "config.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
-DATABASES = {
-    'default': dj_database_url.config(default='sqlite:///db.sqlite3')
-}
+DATABASES = {"default": dj_database_url.config(default="sqlite:///db.sqlite3")}
 
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'America/Los_Angeles'
+TIME_ZONE = "America/Los_Angeles"
 
 USE_I18N = True
 
@@ -115,20 +109,18 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
-STATIC_ROOT = 'staticfiles'
-STATIC_URL = '/static-files/'
+STATIC_ROOT = "staticfiles"
+STATIC_URL = "/static-files/"
 
 # Due to a bug relating to the manifest not being generated before the tests run
 # We can't use CompressedManifestStaticFilesStorage (yet)
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
-STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, 'pythonsd', 'static'),
-)
+STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
+STATICFILES_DIRS = (os.path.join(BASE_DIR, "pythonsd", "static"),)
 STATICFILES_FINDERS = (
-    'pythonsd.static_files.CompileFinder',
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    "pythonsd.static_files.CompileFinder",
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 )
 
-MEDIA_URL = '/media/'
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_URL = "/media/"
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -10,9 +10,5 @@ from .base import *  # noqa
 # Enable Django Debug Toolbar
 # https://django-debug-toolbar.readthedocs.io
 
-INSTALLED_APPS += [
-    'debug_toolbar',
-]
-MIDDLEWARE = [
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-] + MIDDLEWARE
+INSTALLED_APPS += ["debug_toolbar"]
+MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware"] + MIDDLEWARE

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -15,26 +15,68 @@ from .base import *  # noqa
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 DEBUG = False
-SECRET_KEY = os.environ['SECRET_KEY']
+SECRET_KEY = os.environ["SECRET_KEY"]
 ALLOWED_HOSTS = [
-    '127.0.0.1',
-    'pythonsd.org',
-    'www.pythonsd.org',
-    'pythonsd.com',
-    'www.pythonsd.com',
-    'sandiegopython.org',
-    'www.sandiegopython.org',
-    'pythonsd.herokuapp.com',
+    "127.0.0.1",
+    "pythonsd.org",
+    "www.pythonsd.org",
+    "pythonsd.com",
+    "www.pythonsd.com",
+    "sandiegopython.org",
+    "www.sandiegopython.org",
+    "pythonsd.herokuapp.com",
 ]
 
 
 # Set the URL where the admin is accessible
-ADMIN_URL = os.environ.get('ADMIN_URL', 'admin')
+ADMIN_URL = os.environ.get("ADMIN_URL", "admin")
 
 
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
-DATABASES = {
-    'default': dj_database_url.config(),
+DATABASES = {"default": dj_database_url.config()}
+DATABASES["default"]["ATOMIC_REQUESTS"] = True
+DATABASES["default"]["CONN_MAX_AGE"] = 600
+
+
+# Caching
+# https://docs.djangoproject.com/en/1.11/ref/settings/#caches
+# http://niwinz.github.io/django-redis/
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": os.environ["REDIS_URL"],
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "IGNORE_EXCEPTIONS": True,
+        },
+    }
 }
+
+
+# Security
+# https://docs.djangoproject.com/en/1.11/topics/security/
+# https://devcenter.heroku.com/articles/http-routing#heroku-headers
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+SECURE_SSL_HOST = os.environ.get("SECURE_SSL_HOST")
+SECURE_SSL_REDIRECT = True
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
+CSRF_COOKIE_SECURE = True
+CSRF_COOKIE_HTTPONLY = True
+SECURE_HSTS_SECONDS = 60  # TODO: set to 31536000 after verifying
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+SECURE_HSTS_PRELOAD = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_BROWSER_XSS_FILTER = True
+X_FRAME_OPTIONS = "DENY"
+
+
+# Sessions
+# https://docs.djangoproject.com/en/1.11/topics/http/sessions/
+# Don't put sessions in the database
+
+SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,18 +5,14 @@ from revproxy.views import ProxyView
 
 
 urlpatterns = [
-    url(r'^{}/'.format(settings.ADMIN_URL), include(admin.site.urls)),
-
-    url(r'^', include('pythonsd.urls')),
-
+    url(r"^{}/".format(settings.ADMIN_URL), include(admin.site.urls)),
+    url(r"^", include("pythonsd.urls")),
     # Proxy all unmatched requests to the static Pelican site
     # This rule should come absolutely last
-    url(r'^(?P<path>.*)$', ProxyView.as_view(upstream=settings.PYTHONSD_STATIC_SITE)),
+    url(r"^(?P<path>.*)$", ProxyView.as_view(upstream=settings.PYTHONSD_STATIC_SITE)),
 ]
 
 if settings.DEBUG:  # pragma: no cover
     import debug_toolbar
 
-    urlpatterns = [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
-    ] + urlpatterns
+    urlpatterns = [url(r"^__debug__/", include(debug_toolbar.urls))] + urlpatterns

--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -2,3 +2,7 @@
 
 # Database server
 psycopg2==2.8.3 --no-binary psycopg2
+
+# Caching
+django-redis==4.10.0
+redis==3.3.10


### PR DESCRIPTION
This PR is branched from #29. We can either merge this into that PR or if that PR is merged first we can instead point this at master.

- Added a number of [production security settings](https://docs.djangoproject.com/en/1.11/topics/security/)
  * set all cookies to be secure cookies
  * turn on various optional Django security settings
  * set an HTTP -> HTTPS redirect ([SECURE_SSL_REDIRECT](https://docs.djangoproject.com/en/1.11/ref/settings/#secure-ssl-redirect))
  * all other domains redirect to the main domain ([SECURE_SSL_HOST](https://docs.djangoproject.com/en/1.11/ref/settings/#secure-ssl-host))
- Add caching with redis
- Switch the session engine to [secure cookies](https://docs.djangoproject.com/en/1.11/topics/http/sessions/#using-cookie-based-sessions) rather than adding records to the DB indefinitely
- A side effect involved code formatting with black (see #30)

Fixes https://github.com/pythonsd/pythonsd-django/issues/19