### PR TITLE
Fix a configuration issue

### DIFF
--- a/config/settings/__init__.py
+++ b/config/settings/__init__.py
@@ -1,1 +1,0 @@
-from .dev import *  # noqa


### PR DESCRIPTION
I introduced this bug in #29 which causes the dev settings to be read regardless of `DJANGO_SETTINGS_MODULE`.