### PR TITLE
Add CI and testing improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,38 +6,23 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7.4-buster
+      - image: circleci/python:3.7
 
     working_directory: ~/repo
 
     steps:
       - checkout
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "requirements/local.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-
       - run:
           name: install dependencies
           command: |
             python3 -m venv .venv
             . .venv/bin/activate
-            pip install -r requirements/local.txt
-            pip install coverage codecov
-
-      - save_cache:
-          paths:
-            - ./.venv
-          key: v1-dependencies-{{ checksum "requirements/local.txt" }}
+            pip install "tox<4.0"
 
       # run tests!
       - run:
           name: run tests
           command: |
             . .venv/bin/activate
-            pre-commit run --all-files
-            coverage run manage.py test
-            codecov
+            tox

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,35 @@
 [run]
 branch: True
-source: .
+source =
+  config
+  pythonsd
 omit =
   */**/migrations/*
   */**/settings/*
   */**/tests/**
+  */**/tests.py
   wsgi.py
+
+  # Skip local virtual and tox environments
+  */.tox/*
+  */.venv/*
+
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+    if settings\.DEBUG
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Circle CI](https://circleci.com/gh/pythonsd/pythonsd-django/tree/master.svg?style=shield)](https://circleci.com/gh/pythonsd/pythonsd-django/tree/master)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/6u1mssp3co57mi0g/branch/master?svg=true)](https://ci.appveyor.com/project/macro1/pythonsd-django/branch/master)
-[![codecov.io](https://codecov.io/github/pythonsd/pythonsd-django/coverage.svg?branch=master)](https://codecov.io/github/pythonsd/pythonsd-django?branch=master)
 [![Requirements Status](https://requires.io/github/pythonsd/pythonsd-django/requirements.svg?branch=master)](https://requires.io/github/pythonsd/pythonsd-django/requirements/?branch=master)
 
 Install requirements
@@ -33,4 +32,9 @@ Add a superuser
 Run local development server
 ```shell
 ./manage.py runserver
+```
+
+Run tests
+```shell
+tox
 ```

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -12,3 +12,7 @@ from .base import *  # noqa
 
 INSTALLED_APPS += ["debug_toolbar"]
 MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware"] + MIDDLEWARE
+
+
+# Enable template debugging (required for template coverage)
+TEMPLATES[0]["OPTIONS"]["debug"] = DEBUG

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -1,0 +1,7 @@
+"""Settings used in testing."""
+import warnings
+
+from .dev import *  # noqa
+
+
+TESTING = True

--- a/pythonsd/static_files.py
+++ b/pythonsd/static_files.py
@@ -5,7 +5,7 @@ import tasks
 
 class CompileFinder(BaseFinder):
     def find(self, path, all=False):
-        return []
+        return []  # pragma: no cover
 
     def list(self, ignore_patterns):
         """Perform the compile action."""

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -6,6 +6,7 @@ pre-commit==1.18.3
 
 # Used for code coverage
 coverage==4.5.4
+django_coverage_plugin<2.0
 
 # Used in local testing
 WebTest==2.0.21
@@ -14,3 +15,5 @@ WebOb==1.6.1
 
 # Used to help with Django related debugging
 django-debug-toolbar==2.0
+
+tox<4.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+envlist = py37,lint
+skipsdist = True
+
+
+[testenv]
+description = run test suite for the application with {basepython}
+setenv =
+    PYTHONPATH={toxinidir}
+    DJANGO_SETTINGS_MODULE=config.settings.test
+    DJANGO_SETTINGS_SKIP_LOCAL=True
+deps = -r{toxinidir}/requirements/local.txt
+commands =
+    # Ensure there aren't missing migrations
+    ./manage.py makemigrations --check --dry-run
+
+    # Run the tests and report coverage
+    coverage run ./manage.py test
+
+    # Fail for under 100% coverage
+    coverage report --show-missing --fail-under=100
+
+
+[testenv:lint]
+description = run through the pre-commit and pylint to check coding standards
+deps = -r{toxinidir}/requirements/local.txt
+commands =
+    pre-commit run --all-files


### PR DESCRIPTION
- Fail under 100% coverage
- Run all tests exactly like CI through tox

Note: this change does not enable `django_coverage_plugin` which can't actually scan our templates because they are Jinja templates instead of Django templates. This is another point for #27.