### PR TITLE
Remove codecov from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,7 @@
 install:
   - "SET PATH=C:\\Python37;C:\\Python37\\Scripts;C:\\Program Files\\PostgreSQL\\9.4\\bin;%PATH%"
   - "pip install --requirement requirements/local.txt"
-  - "pip install coverage"
 
 build: off
 
 test_script: coverage run manage.py test
-
-after_test:
-  - pip install codecov
-  - codecov


### PR DESCRIPTION
- Coverage is handled locally and we fail below 100 (see tox.ini)

Appveyor seemed to call codecov in #41.