### PR TITLE
Send email with Sendgrid

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -118,3 +118,11 @@ STATICFILES_FINDERS = (
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
+
+
+# Email
+# https://docs.djangoproject.com/en/1.11/topics/email/
+
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+DEFAULT_FROM_EMAIL = "noreply@sandiegopython.org"
+SERVER_EMAIL = DEFAULT_FROM_EMAIL

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -80,3 +80,13 @@ X_FRAME_OPTIONS = "DENY"
 # Don't put sessions in the database
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+
+
+# Email
+# https://docs.djangoproject.com/en/1.11/topics/email/
+# https://anymail.readthedocs.io/en/stable/
+
+if "SENDGRID_API_KEY" in os.environ:
+    INSTALLED_APPS += ["anymail"]
+    EMAIL_BACKEND = "anymail.backends.sendgrid.EmailBackend"
+    ANYMAIL = {"SENDGRID_API_KEY": os.environ["SENDGRID_API_KEY"]}

--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -6,3 +6,6 @@ psycopg2==2.8.3 --no-binary psycopg2
 # Caching
 django-redis==4.10.0
 redis==3.3.10
+
+# Email
+django-anymail==7.0.0


### PR DESCRIPTION
- This is optional based on envvars
- Uses [anymail](https://anymail.readthedocs.io) behind the scenes
- This makes Django's regular "send_mail" func work like magic