### PR TITLE
Enforce a single hostname for the site

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "enforce_host.EnforceHostMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -74,6 +74,10 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True
 X_FRAME_OPTIONS = "DENY"
 
+# If set, all requests to other domains redirect to this one
+# https://github.com/dabapps/django-enforce-host
+ENFORCE_HOST = os.environ.get("ENFORCE_HOST", None)
+
 
 # Sessions
 # https://docs.djangoproject.com/en/1.11/topics/http/sessions/

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -21,3 +21,6 @@ requests==2.22.0
 
 # For serving static assets from the WSGI server
 whitenoise==4.1.4
+
+# Redirects requests to other hosts to this one
+django-enforce-host==1.0.1


### PR DESCRIPTION
This change allows us with a single configuration to canonicalize the domain. For example, setting the envvar `ENFORCE_HOST='www.sandiegopython.org'` would cause all other domains allowed for this website (eg. "pythonsd.org", "sandiegopython.org", "pythonsd.herokuapp.com") to permanent (301) redirect to to www.sandiegopython.org.

## Notes

* By itself, this PR doesn't canonicalize the domain since the envvar still has to be set. This PR is OK to merge even if we haven't agreed on a canonical domain.
* Since these are 301 redirects we should agree on the domain to canonicalize on this since it isn't cleanly reversible.

Refs #19, #39