### PR TITLE
Fix Django 3 production incompatibility

### DIFF
--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -4,7 +4,7 @@
 psycopg2-binary==2.9.5
 
 # Caching
-django-redis==4.10.0
+django-redis==5.2.0
 redis==3.3.10
 
 # Email


### PR DESCRIPTION
This version of django-redis has an incompatibility with Django 3+. It needed to be upgraded.