### PR TITLE
Switch to gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,4 @@ RUN date -u +'%Y-%m-%dT%H:%M:%SZ' > BUILD_DATE
 
 EXPOSE 8000
 
-# Increase the timeout since these PDFs take a long time to generate
-CMD ["waitress-serve", "--port=8000", "config.wsgi:application"]
+CMD ["gunicorn", "--timeout", "15", "--bind", ":8000", "--workers", "2", "--max-requests", "10000", "--max-requests-jitter", "100", "config.wsgi"]

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ Django==3.2.18
 pytz==2022.7.1
 
 # A zero dependency WSGI server
-waitress==2.1.2
+gunicorn==20.1.0
 
 # For connecting to various APIs (eg. Meetup.com)
 requests==2.22.0


### PR DESCRIPTION
Historically, this repo has used waitress instead of gunicorn which I am more familiar with. This dates back to when Micah set this repo up.

However, I get alerted when the site goes down or has issues. Since switching to Fly and more specifically since having the async views, I've seen some issues on Fly with the site.

I'm hoping by using gunicorn with some limits that the issues go away.

Specifically, I've seen requests queuing up on waitress with the following log message. This issue won't clear for many minutes. I'm not sure why waitress doesn't timeout requests and get back to a good state.

```
2023-03-18T00:20:45.669 app[4b9dfb35] lax [info] WARNING 2023-03-17 17:20:45,669 [waitress.queue] Task queue depth is 1
2023-03-18T00:20:45.805 app[4b9dfb35] lax [info] WARNING 2023-03-17 17:20:45,804 [waitress.queue] Task queue depth is 1
2023-03-18T00:20:52.235 app[4b9dfb35] lax [info] WARNING 2023-03-17 17:20:52,234 [waitress.queue] Task queue depth is 2
2023-03-18T00:20:55.043 app[4b9dfb35] lax [info] WARNING 2023-03-17 17:20:55,043 [waitress.queue] Task queue depth is 3
2023-03-18T00:21:03.431 app[4b9dfb35] lax [info] WARNING 2023-03-17 17:21:03,430 [waitress.queue] Task queue depth is 4
2023-03-18T00:21:08.104 app[4b9dfb35] lax [info] WARNING 2023-03-17 17:21:08,104 [waitress.queue] Task queue depth is 5
2023-03-18T00:21:13.760 app[4b9dfb35] lax [info] WARNING 2023-03-17 17:21:13,760 [waitress.queue] Task queue depth is 6
2023-03-18T00:21:15.274 app[4b9dfb35] lax [info] WARNING 2023-03-17 17:21:15,274 [waitress.queue] Task queue depth is 7
```