### PR TITLE
Remove requires.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This is the repository for the San Diego Python website at [sandiegopython.org](https://sandiegopython.org).
 
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/184l9lc8y7av2fah?svg=true)](https://ci.appveyor.com/project/davidfischer/pythonsd-django)
-[![Requirements Status](https://requires.io/github/sandiegopython/pythonsd-django/requirements.svg?branch=main)](https://requires.io/github/sandiegopython/pythonsd-django/requirements/?branch=main)
 
 
 ## Developing


### PR DESCRIPTION
Requires.io is gone. It was a service to check if our requirements are up-to-date (hint: they aren't). Remove it from the readme.