### PR TITLE
refactor: update verbiage for single video

### DIFF
--- a/pythonsd/templates/pythonsd/index.html
+++ b/pythonsd/templates/pythonsd/index.html
@@ -78,7 +78,7 @@
         </div> <!-- /col -->
 
         <div class="col-lg-6">
-          <h3>Recent videos &amp; streams</h3>
+          <h3>Latest video</h3>
 
           <div id="youtube-widget" hx-get="{% url 'recent_videos' %}" hx-trigger="load">
             <p class="small py-5">Loading...</p>


### PR DESCRIPTION
The header should indicate that only one video is below. This avoids confusion for the user wondering if more videos are loading.

Once more videos are loaded here (or linked to a separate page) this change will need to be reverted.