### PR TITLE
Silence a dev-only Django staticfiles warning

### DIFF
--- a/assets/dist/.gitkeep
+++ b/assets/dist/.gitkeep
@@ -1,0 +1,2 @@
+This file silences a dev-only Django warning
+that occurs when the staticfiles directory doesn't exist.

--- a/staticfiles/.gitkeep
+++ b/staticfiles/.gitkeep
@@ -1,0 +1,2 @@
+This file silences a dev-only Django warning
+that occurs when the staticfiles directory doesn't exist.


### PR DESCRIPTION
Django emits a warning when running tests if `STATIC_ROOT` doesn't exist. That directory is normally only created after running `collectstatic`. This would be a serious error in prod, but isn't a big deal in dev.

Regardless, it's easy to silence the warning by creating an empty directory.