### PR TITLE
refactor/docs: removed mentions of Heroku

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -26,7 +26,6 @@ ALLOWED_HOSTS = [
     "www.pythonsd.com",
     "sandiegopython.org",
     "www.sandiegopython.org",
-    "pythonsd.herokuapp.com",  # RIP
     "pythonsd-django.fly.dev",
 ]
 
@@ -62,7 +61,6 @@ if "REDIS_URL" in os.environ:
 
 # Security
 # https://docs.djangoproject.com/en/3.2/topics/security/
-# https://devcenter.heroku.com/articles/http-routing#heroku-headers
 # --------------------------------------------------------------------------
 if "SECURE_SSL_HOST" in os.environ:
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # Install requirements for local development with:
 # pip install -r requirements/local.txt
 
-# Requirements needed by Heroku for deployment
+# Requirements needed for deployment
 -r requirements/deployment.txt


### PR DESCRIPTION
Heroku no longer needs to be listed as an allowed host or mentioned in comments.