### PR TITLE
refactor: prevent logo click reloading homepage if already there

### DIFF
--- a/assets/src/sass/_theme.scss
+++ b/assets/src/sass/_theme.scss
@@ -1,7 +1,5 @@
-.navbar-brand {
-  img {
-    width: 8rem;
-  }
+#navbar-logo {
+  width: 8rem;
 }
 
 .jumbotron {

--- a/assets/src/sass/_theme.scss
+++ b/assets/src/sass/_theme.scss
@@ -1,5 +1,7 @@
-#navbar-logo {
-  width: 8rem;
+.navbar-brand {
+  img {
+    width: 8rem;
+  }
 }
 
 .jumbotron {

--- a/pythonsd/templates/pythonsd/base.html
+++ b/pythonsd/templates/pythonsd/base.html
@@ -23,14 +23,10 @@
 
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    {% url 'index' as index_url %}
-    {% if request.path == index_url %}
-		<img src="{% static 'img/sandiegopython-logo.svg' %}" id="navbar-logo" class="navbar-brand" alt="San Diego Python Home">
-    {% else %}
-      <a class="navbar-brand" href="{{ index_url }}">
-		<img src="{% static 'img/sandiegopython-logo.svg' %}" id="navbar-logo" alt="San Diego Python Home">
+      {% url 'index' as index_url %}
+      <a class="navbar-brand" href="{% if request.path != index_url %}{{ index_url }}{% else %}#{% endif %}">
+        <img src="{% static 'img/sandiegopython-logo.svg' %}" id="navbar-logo" alt="San Diego Python Home">
       </a>
-    {% endif %}
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbars-expand" aria-controls="navbars-expand" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/pythonsd/templates/pythonsd/base.html
+++ b/pythonsd/templates/pythonsd/base.html
@@ -25,12 +25,12 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     {% url 'index' as index_url %}
     {% if request.path == index_url %}
-      <a class="navbar-brand" href="#">
+		<img src="{% static 'img/sandiegopython-logo.svg' %}" id="navbar-logo" class="navbar-brand" alt="San Diego Python Home">
     {% else %}
       <a class="navbar-brand" href="{{ index_url }}">
-    {% endif %}
-        <img src="{% static 'img/sandiegopython-logo.svg' %}" alt="San Diego Python Home">
+		<img src="{% static 'img/sandiegopython-logo.svg' %}" id="navbar-logo" alt="San Diego Python Home">
       </a>
+    {% endif %}
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbars-expand" aria-controls="navbars-expand" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/pythonsd/templates/pythonsd/base.html
+++ b/pythonsd/templates/pythonsd/base.html
@@ -23,7 +23,12 @@
 
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-      <a class="navbar-brand" href="{% url 'index' %}">
+    {% url 'index' as index_url %}
+    {% if request.path == index_url %}
+      <a class="navbar-brand" href="#">
+    {% else %}
+      <a class="navbar-brand" href="{{ index_url }}">
+    {% endif %}
         <img src="{% static 'img/sandiegopython-logo.svg' %}" alt="San Diego Python Home">
       </a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbars-expand" aria-controls="navbars-expand" aria-expanded="false" aria-label="Toggle navigation">

--- a/pythonsd/templates/pythonsd/base.html
+++ b/pythonsd/templates/pythonsd/base.html
@@ -25,7 +25,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       {% url 'index' as index_url %}
       <a class="navbar-brand" href="{% if request.path != index_url %}{{ index_url }}{% else %}#{% endif %}">
-        <img src="{% static 'img/sandiegopython-logo.svg' %}" id="navbar-logo" alt="San Diego Python Home">
+        <img src="{% static 'img/sandiegopython-logo.svg' %}" alt="San Diego Python Home">
       </a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbars-expand" aria-controls="navbars-expand" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
This is only necessary if you agree with [this comment](https://ux.stackexchange.com/a/55642) about it being a design error. There's also the very small impact to bandwidth of an unnecessary page load (pretty insignificant for the site's traffic, though).

A different option is to keep the anchor tag and only adjust the href to "#".  This tells users that the logo is clickable without reloading the page.