### PR TITLE
feat: add database-driven organizer page

### DIFF
--- a/pythonsd/admin.py
+++ b/pythonsd/admin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+from .models import Organizer
+
+admin.site.register(Organizer)

--- a/pythonsd/models.py
+++ b/pythonsd/models.py
@@ -1,0 +1,11 @@
+from django.db import models
+
+
+class Organizer(models.Model):
+    name = models.CharField(max_length=255)
+    meetup_url = models.CharField(max_length=255)
+    linkedin_url = models.CharField(max_length=255, blank=True)
+    active = models.BooleanField(default=True)
+
+    def __str__(self):
+        return self.name

--- a/pythonsd/templates/pythonsd/base.html
+++ b/pythonsd/templates/pythonsd/base.html
@@ -39,9 +39,9 @@
           <!-- <li class="nav-item">
             <a class="nav-link" href="#">Support Us</a>
           </li> -->
-          <!-- <li class="nav-item">
-            <a class="nav-link" href="#">Organizers</a>
-          </li> -->
+          <li class="nav-item">
+            <a class="nav-link" href="{% url 'organizers' %}">Organizers</a>
+          </li>
         </ul>
       </div>
     </nav>

--- a/pythonsd/templates/pythonsd/organizers.html
+++ b/pythonsd/templates/pythonsd/organizers.html
@@ -7,9 +7,7 @@
 
 <p>If you would like to reach out, please contact the <a href="mailto:sandiegopython-organizers@googlegroups.com">Python SD Organizers</a>.</p>
 
-{% comment %} <h3>Active Organizers</h3> {% endcomment %}
-
-{% for organizer in active_organizers %}
+  {% for organizer in active_organizers %}
     <h5>{{ organizer.name }}</h5>
     <p><a href="{{ organizer.meetup_url }}" rel="nofollow noopener noreferrer" target="_blank">Meetup</a>
     {% if organizer.linkedin_url %}
@@ -17,17 +15,6 @@
     {% endif %}
     </p>
 {% endfor %}
-
-{% comment %} <h3>Past Organizers</h3>
-
-{% for organizer in past_organizers %}
-    <h5>{{ organizer.name }}</h5>
-    <p><a href="{{ organizer.meetup_url }}" rel="nofollow noopener noreferrer" target="_blank">Meetup Profile</a>
-    {% if organizer.linkedin_url %}
-        |&nbsp;<a href="{{ organizer.linkedin_url }}" rel="nofollow noopener noreferrer" target="_blank">LinkedIn Profile</a>
-    {% endif %}
-    </p>
-{% endfor %} {% endcomment %}
 
 </div>
 {% endblock main %}

--- a/pythonsd/templates/pythonsd/organizers.html
+++ b/pythonsd/templates/pythonsd/organizers.html
@@ -1,0 +1,33 @@
+{% extends 'pythonsd/base.html' %}
+
+
+{% block main %}
+<div class="container mt-3">
+<h1>Organizers</h1>
+
+<p>If you would like to reach out, please contact the <a href="mailto:sandiegopython-organizers@googlegroups.com">Python SD Organizers</a>.</p>
+
+{% comment %} <h3>Active Organizers</h3> {% endcomment %}
+
+{% for organizer in active_organizers %}
+    <h5>{{ organizer.name }}</h5>
+    <p><a href="{{ organizer.meetup_url }}" rel="nofollow noopener noreferrer" target="_blank">Meetup</a>
+    {% if organizer.linkedin_url %}
+        |&nbsp;<a href="{{ organizer.linkedin_url }}" rel="nofollow noopener noreferrer" target="_blank">LinkedIn</a>
+    {% endif %}
+    </p>
+{% endfor %}
+
+{% comment %} <h3>Past Organizers</h3>
+
+{% for organizer in past_organizers %}
+    <h5>{{ organizer.name }}</h5>
+    <p><a href="{{ organizer.meetup_url }}" rel="nofollow noopener noreferrer" target="_blank">Meetup Profile</a>
+    {% if organizer.linkedin_url %}
+        |&nbsp;<a href="{{ organizer.linkedin_url }}" rel="nofollow noopener noreferrer" target="_blank">LinkedIn Profile</a>
+    {% endif %}
+    </p>
+{% endfor %} {% endcomment %}
+
+</div>
+{% endblock main %}

--- a/pythonsd/tests/__init__.py
+++ b/pythonsd/tests/__init__.py
@@ -17,8 +17,30 @@ import responses
 import webtest
 
 from config import wsgi
+from ..models import Organizer
 from ..views import RecentVideosView
 from ..views import UpcomingEventsView
+
+
+class OrganizerTestCase(test.TestCase):
+    def setUp(self):
+        Organizer.objects.create(
+            name="David Fischer",
+            meetup_url="https://www.meetup.com/members/35125652/",
+            linkedin_url="https://www.linkedin.com/in/davidjamesfischer",
+        )
+        Organizer.objects.create(
+            name="Micah Denbraver",
+            meetup_url="https://www.meetup.com/members/76383362/",
+            active=False,
+        )
+
+    def test_organizer__str__(self):
+        """Organizer __str__ is properly displayed as the name field"""
+        david = Organizer.objects.get(name="David Fischer")
+        micah = Organizer.objects.get(name="Micah Denbraver")
+        self.assertEqual(str(david), "David Fischer")
+        self.assertEqual(str(micah), "Micah Denbraver")
 
 
 class TestBasicViews(test.TestCase):

--- a/pythonsd/tests/__init__.py
+++ b/pythonsd/tests/__init__.py
@@ -42,13 +42,13 @@ class OrganizerTestCase(test.TestCase):
         self.assertEqual(str(david), "David Fischer")
         self.assertEqual(str(micah), "Micah Denbraver")
 
-
-class TestBasicViews(test.TestCase):
     def test_organizers(self):
         response = self.client.get(reverse("organizers"))
         self.assertContains(response, "<h1>Organizers</h1>")
         self.assertIsInstance(response.context["active_organizers"], QuerySet)
 
+
+class TestBasicViews(test.TestCase):
     def test_code_of_conduct(self):
         response = self.client.get(reverse("code-of-conduct"))
         self.assertContains(response, "<h1>Code of Conduct</h1>")

--- a/pythonsd/tests/__init__.py
+++ b/pythonsd/tests/__init__.py
@@ -11,6 +11,7 @@ from unittest import mock
 from django import test
 from django.core.cache import cache
 from django.conf import settings
+from django.db.models import QuerySet
 from django.urls import reverse
 import responses
 import webtest
@@ -21,6 +22,12 @@ from ..views import UpcomingEventsView
 
 
 class TestBasicViews(test.TestCase):
+    def test_organizers(self):
+        response = self.client.get(reverse("organizers"))
+        self.assertContains(response, "<h1>Organizers</h1>")
+        self.assertIsInstance(response.context["active_organizers"], QuerySet)
+        # self.assertIsInstance(response.context["past_organizers"], QuerySet)
+
     def test_code_of_conduct(self):
         response = self.client.get(reverse("code-of-conduct"))
         self.assertContains(response, "<h1>Code of Conduct</h1>")

--- a/pythonsd/tests/__init__.py
+++ b/pythonsd/tests/__init__.py
@@ -26,7 +26,6 @@ class TestBasicViews(test.TestCase):
         response = self.client.get(reverse("organizers"))
         self.assertContains(response, "<h1>Organizers</h1>")
         self.assertIsInstance(response.context["active_organizers"], QuerySet)
-        # self.assertIsInstance(response.context["past_organizers"], QuerySet)
 
     def test_code_of_conduct(self):
         response = self.client.get(reverse("code-of-conduct"))

--- a/pythonsd/urls.py
+++ b/pythonsd/urls.py
@@ -23,6 +23,11 @@ urlpatterns = [
         generic.TemplateView.as_view(template_name="pythonsd/code-of-conduct.html"),
         name="code-of-conduct",
     ),
+    path(
+        r"organizers/",
+        views.OrganizersView.as_view(template_name="pythonsd/organizers.html"),
+        name="organizers",
+    ),
     # XHR/Async requests
     path(r"xhr/events/", views.UpcomingEventsView.as_view(), name="upcoming_events"),
     path(r"xhr/videos/", views.RecentVideosView.as_view(), name="recent_videos"),

--- a/pythonsd/views.py
+++ b/pythonsd/views.py
@@ -33,9 +33,6 @@ class OrganizersView(TemplateView):
         context["active_organizers"] = (
             Organizer.objects.filter(active=True).order_by('name')
         )
-        # context["past_organizers"] = (
-        #     Organizer.objects.filter(active=False).order_by('name')
-        # )
         return context
 
 

--- a/pythonsd/views.py
+++ b/pythonsd/views.py
@@ -10,6 +10,8 @@ import pytz
 import requests
 from defusedxml import ElementTree
 
+from .models import Organizer
+
 
 CACHE_DURATION = 60 * 15  # 15 minutes
 log = logging.getLogger(__file__)
@@ -19,6 +21,22 @@ class HomePageView(TemplateView):
     """Displays the homepage."""
 
     template_name = "pythonsd/index.html"
+
+
+class OrganizersView(TemplateView):
+    """Displays SD Python organizers."""
+
+    template_name = "pythonsd/organizers.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["active_organizers"] = (
+            Organizer.objects.filter(active=True).order_by('name')
+        )
+        # context["past_organizers"] = (
+        #     Organizer.objects.filter(active=False).order_by('name')
+        # )
+        return context
 
 
 @method_decorator(cache_page(CACHE_DURATION), name="dispatch")


### PR DESCRIPTION
Resolves #64 

Organizers will need to be manually added to the database via /admin/. By default, these changes will only show active organizers and will link to their Meetup profile and LinkedIn (optional).

There are commented lines in `views.py`, `__init__.py`, and `organizers.html` that could display past organizers below active organizers. This would be a good way to honor those that have helped in the past. This would require more manual work adding extra people in /admin/ and changing their active status to False.