### PR TITLE
Use docker compose for debugging production

### DIFF
--- a/.env/local.sample
+++ b/.env/local.sample
@@ -1,8 +1,33 @@
 # This is a sample of environment variables which are used only to run Docker locally.
 # These are never used in production.
 
+# Django
+# ------------------------------------------------------------------------------
+# Run Django in production mode (DEBUG=False)
+DJANGO_SETTINGS_MODULE=config.settings.prod
+
 # Use a strong secret in production
 SECRET_KEY="this-is-a-bad-secret"
 
-# In production, we use postgres but for testing a deployment, using SQLite is fine
-DATABASE_URL="sqlite:///db.sqlite3"
+
+# PostgreSQL
+# ------------------------------------------------------------------------------
+# This must match .env/postgres
+DATABASE_URL=pgsql://localuser:localpass@postgres:5432/sandiegopython
+
+
+# Redis
+# ------------------------------------------------------------------------------
+REDIS_URL=redis://redis:6379/0
+
+
+# S3/R2 Media Storage
+# ------------------------------------------------------------------------------
+# If not empty, S3/R2 will be used for media storage
+AWS_S3_ACCESS_KEY_ID=
+AWS_S3_SECRET_ACCESS_KEY=
+AWS_STORAGE_BUCKET_NAME=
+# If using a custom storage for media storage, set the MEDIA_URL
+MEDIA_URL=/media/
+# The endpoint URL is necessary for Cloudflare R2
+AWS_S3_ENDPOINT_URL=

--- a/.env/local.sample
+++ b/.env/local.sample
@@ -27,7 +27,9 @@ REDIS_URL=redis://redis:6379/0
 AWS_S3_ACCESS_KEY_ID=
 AWS_S3_SECRET_ACCESS_KEY=
 AWS_STORAGE_BUCKET_NAME=
-# If using a custom storage for media storage, set the MEDIA_URL
+# If using a custom domain for media storage, set the MEDIA_URL
+#  and AWS_S3_CUSTOM_DOMAIN
+AWS_S3_CUSTOM_DOMAIN=
 MEDIA_URL=/media/
 # The endpoint URL is necessary for Cloudflare R2
 AWS_S3_ENDPOINT_URL=

--- a/.env/postgres
+++ b/.env/postgres
@@ -1,0 +1,7 @@
+# PostgreSQL
+# ------------------------------------------------------------------------------
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=sandiegopython
+POSTGRES_USER=localuser
+POSTGRES_PASSWORD=localpass

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
-.PHONY: help test clean deploy
+.PHONY: help test clean dockerbuild dockerserve dockershell deploy
+
+
+DOCKER_CONFIG=compose.yaml
 
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  test           Run the full test suite"
 	@echo "  clean          Delete assets processed by webpack"
+	@echo "  dockerbuild    Build the Docker compose dev environment"
+	@echo "  dockerserve    Run the Docker containers for the site"
+	@echo "                 (starts a webserver on http://localhost:8000)"
+	@echo "  dockershell    Connect to a bash shell on the Django Docker container"
 	@echo "  deploy         Deploy the app to fly.io"
 
 
@@ -13,6 +20,21 @@ test:
 
 clean:
 	rm -rf assets/dist/*
+
+# Build the local multi-container application
+# This command can take a while the first time
+dockerbuild:
+	docker compose -f $(DOCKER_CONFIG) build
+
+# You should run "dockerbuild" at least once before running this
+# It isn't a dependency because running "dockerbuild" can take some time
+dockerserve:
+	docker compose -f $(DOCKER_CONFIG) up
+
+# Use this command to inspect the container, run management commands,
+# or run anything else on the Django container
+dockershell:
+	docker compose -f $(DOCKER_CONFIG) run --rm django /bin/bash
 
 # Build and deploy the production container
 deploy:

--- a/README.md
+++ b/README.md
@@ -42,13 +42,19 @@ you can build the container and run it locally:
 cp .env/local.sample .env/local
 
 # Build the docker image for sandiegopython.org
-docker buildx build -t sandiegopython.org .
+# Use Docker compose to have Redis and PostgreSQL just like in production
+# Note: Docker is used in production but Docker compose is just for development
+make dockerbuild
 
-# Start a development server on http://localhost:8000
-docker run --env-file=".env/local" --publish=8000:8000 sandiegopython.org
+# Start a development web server on http://localhost:8000
+# Use ctrl+C to stop
+make dockerserve
 
-# You can start a shell to the container with the following:
-docker run --env-file=".env/local" -it sandiegopython.org /bin/bash
+# While the server is running,
+# you can start a bash shell to the container with the following:
+# Once you have a bash shell, you can run migrations,
+# manually connect to the local Postgres database or anything else
+make dockershell
 ```
 
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,40 @@
+# Docker Compose Local Development Setup
+#
+# This starts a local multi-container development environment
+# with Postgres, Redis, and Django.
+# The configuration comes from .env/local and .env/postgres
+#
+# To run:
+#   $ make dockerbuild
+#   $ make dockerserve
+
+volumes:
+  local_postgres_data: {}
+
+services:
+  django:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    image: sandiegopython_local_django
+    depends_on:
+      - postgres
+    env_file:
+      - ./.env/local
+      - ./.env/postgres
+    ports:
+      - "${SANDIEGOPYTHON_DJANGO_PORT:-8000}:8000"
+    # Allow us to run `docker attach` and get
+    # control on STDIN and be able to debug our code with interactive pdb
+    stdin_open: true
+    tty: true
+
+  postgres:
+    image: postgres:15.2
+    volumes:
+      - local_postgres_data:/var/lib/postgresql/data
+    env_file:
+      - ./.env/postgres
+
+  redis:
+    image: redis:5.0

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -116,7 +116,7 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "pythonsd", "static"),
 ]
 
-MEDIA_URL = "/media/"
+MEDIA_URL = os.environ.get("MEDIA_URL", default="/media/")
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -41,6 +41,9 @@ ADMIN_URL = os.environ.get("ADMIN_URL", "admin")
 AWS_S3_ACCESS_KEY_ID = os.environ.get("AWS_S3_ACCESS_KEY_ID")
 AWS_S3_SECRET_ACCESS_KEY = os.environ.get("AWS_S3_SECRET_ACCESS_KEY")
 AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STORAGE_BUCKET_NAME")
+# When using media storage with a custom domain
+# set this and set MEDIA_URL
+AWS_S3_CUSTOM_DOMAIN = os.environ.get("AWS_S3_CUSTOM_DOMAIN")
 # The endpoint URL is necessary for Cloudflare R2
 AWS_S3_ENDPOINT_URL = os.environ.get("AWS_S3_ENDPOINT_URL", default=None)
 if AWS_S3_ACCESS_KEY_ID and AWS_S3_SECRET_ACCESS_KEY and AWS_STORAGE_BUCKET_NAME:

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -34,6 +34,19 @@ ALLOWED_HOSTS = [
 ADMIN_URL = os.environ.get("ADMIN_URL", "admin")
 
 
+# Django-storages
+# https://django-storages.readthedocs.io
+# --------------------------------------------------------------------------
+# Optionally store media files in S3/R2/etc.
+AWS_S3_ACCESS_KEY_ID = os.environ.get("AWS_S3_ACCESS_KEY_ID")
+AWS_S3_SECRET_ACCESS_KEY = os.environ.get("AWS_S3_SECRET_ACCESS_KEY")
+AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STORAGE_BUCKET_NAME")
+# The endpoint URL is necessary for Cloudflare R2
+AWS_S3_ENDPOINT_URL = os.environ.get("AWS_S3_ENDPOINT_URL", default=None)
+if AWS_S3_ACCESS_KEY_ID and AWS_S3_SECRET_ACCESS_KEY and AWS_STORAGE_BUCKET_NAME:
+    DEFAULT_FILE_STORAGE = "storages.backends.s3.S3Storage"
+
+
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 # --------------------------------------------------------------------------

--- a/pythonsd/models.py
+++ b/pythonsd/models.py
@@ -12,7 +12,7 @@ class Organizer(models.Model):
         help_text="Set to False to hide this organizer from the organizers page",
     )
 
-    # For production, store the image in Cloud Storage (S3, Appwrite, etc.)
+    # For production, store the image in Cloud Storage (S3, R2, Appwrite, etc.)
     photo = models.ImageField(
         upload_to="organizers/",
         help_text="Recommended size of 400*400px or larger square",

--- a/pythonsd/templates/pythonsd/organizers.html
+++ b/pythonsd/templates/pythonsd/organizers.html
@@ -1,5 +1,4 @@
 {% extends 'pythonsd/base.html' %}
-{% load static %}
 
 
 {% block title %}Organizers{% endblock title %}
@@ -17,7 +16,7 @@
   {% for organizer in organizers %}
   <div class="col mb-4">
     <div class="card">
-      <img src="{% get_media_prefix %}{{ organizer.photo.name }}" class="card-img-top" alt="{{ organizer.name }}">
+      <img src="{{ organizer.photo.url }}" class="card-img-top" alt="{{ organizer.name }}">
       <div class="card-body">
         <h5 class="card-title">{{ organizer.name }}</h5>
         <p class="card-text">{{ organizer.description }}</p>

--- a/pythonsd/templates/pythonsd/organizers.html
+++ b/pythonsd/templates/pythonsd/organizers.html
@@ -1,4 +1,5 @@
 {% extends 'pythonsd/base.html' %}
+{% load static %}
 
 
 {% block title %}Organizers{% endblock title %}
@@ -16,7 +17,7 @@
   {% for organizer in organizers %}
   <div class="col mb-4">
     <div class="card">
-      <img src="{{ organizer.photo.url }}" class="card-img-top" alt="{{ organizer.name }}">
+      <img src="{% get_media_prefix %}{{ organizer.photo.name }}" class="card-img-top" alt="{{ organizer.name }}">
       <div class="card-body">
         <h5 class="card-title">{{ organizer.name }}</h5>
         <p class="card-text">{{ organizer.description }}</p>

--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -8,3 +8,6 @@ django-redis==5.4.0
 
 # Email
 django-anymail==10.3
+
+# Cloud storage for media storage (S3, R2, etc.)
+django-storages[s3]==1.14.3


### PR DESCRIPTION
- Add a docker compose environment with Redis and Postgres
- Add django-storages for storing media files in S3/R2

Branched from #156.


## Rationale
While working on #156, I needed a setup a bit closer to production. Specifically I needed a setup that used Postgres and I wanted to use [django-storages](https://django-storages.readthedocs.io/) to store media files instead of the local filesystem.

## Testing
With docker and docker-compose installed, you should be able to run

```bash
# Builds the docker compose setup with Postgres
make dockerbuild

# Then this will create a dev server (but with Django's DEBUG=False) on http://localhost:8000
make dockerserve
```

Without setting anything, it will store media in a local media directory that will disappear when you close down the server. The plan is to use cloud storage in production. I plan to use R2 and stay *well under* the [free tier](https://developers.cloudflare.com/r2/pricing/). I tested this out and it seemed to work well.

You still should be able to run the default `./manage.py runserver` if you prefer.

## Deploying
The environment variables needed for this change are already staged in fly.io. Since there's no code that uses them yet, they're not doing anything. However, if this is merged into prod, the envvars will take effect and media storage should hopefully *just work*.