### PR TITLE
Update tox.ini command for Django 4.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
 deps = -r{toxinidir}/requirements/local.txt
 commands =
     # Ensure there aren't missing migrations
-    python manage.py makemigrations --check --dry-run
+    python manage.py makemigrations --check
 
     # Run the tests and report coverage
     coverage run ./manage.py test


### PR DESCRIPTION
Note: this is an extremely minor change and isn't really necessary, just a small technicality. 

`--check` implies `--dry-run` in Django>=4.2

I came across this [SO thread](https://stackoverflow.com/questions/76358765/django-makemigrations-check-with-output) and confirmed it in the [Django docs](https://docs.djangoproject.com/en/4.2/ref/django-admin/#cmdoption-makemigrations-check).