### PR TITLE
Add hx-boost to header nav

### DIFF
--- a/pythonsd/templates/pythonsd/base.html
+++ b/pythonsd/templates/pythonsd/base.html
@@ -22,7 +22,7 @@
 
   <body>
     <header class="bg-slate-700">
-      <nav class="container flex flex-wrap justify-between items-center py-6">
+      <nav class="container flex flex-wrap justify-between items-center py-6" hx-boost="true">
         {% url 'index' as index_url %}
         <a href="{% if request.path != index_url %}{{ index_url }}{% else %}#{% endif %}">
           <img class="max-h-12" src="{% static 'img/sandiegopython-logo.svg' %}" alt="San Diego Python Home">


### PR DESCRIPTION
This is a very small optimization using [hx-boost](https://htmx.org/attributes/hx-boost/).

Instead of navigating to a new page, internal links will use an AJAX request and replace the current page in place. The previous page is added to the browser's history and can still be navigated to using the back button. The docs mention the `<body>` tag, but it actually replaces all html.