### PR TITLE
Update black repo url in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/ambv/black
+-   repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.4.2
     hooks:
     - id: black


### PR DESCRIPTION
ambv is a few recommendations old. The latest one is described at https://black.readthedocs.io/en/stable/integrations/source_version_control.html