### PR TITLE
Remove Redis from the cache configuration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -134,6 +134,16 @@ DEFAULT_FROM_EMAIL = "noreply@sandiegopython.org"
 SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 
+# Caching
+# https://docs.djangoproject.com/en/4.2/ref/settings/#caches
+# --------------------------------------------------------------------------
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    }
+}
+
+
 # Logging
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -58,23 +58,6 @@ DATABASES["default"]["ATOMIC_REQUESTS"] = True
 DATABASES["default"]["CONN_MAX_AGE"] = 600
 
 
-# Caching
-# https://docs.djangoproject.com/en/4.2/ref/settings/#caches
-# http://niwinz.github.io/django-redis/
-# --------------------------------------------------------------------------
-if "REDIS_URL" in os.environ:
-    CACHES = {
-        "default": {
-            "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": os.environ["REDIS_URL"],
-            "OPTIONS": {
-                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-                "IGNORE_EXCEPTIONS": True,
-            },
-        }
-    }
-
-
 # Security
 # https://docs.djangoproject.com/en/4.2/topics/security/
 # --------------------------------------------------------------------------

--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -3,9 +3,6 @@
 # Database server
 psycopg2-binary==2.9.9
 
-# Caching
-django-redis==5.4.0
-
 # Email
 django-anymail==10.3
 


### PR DESCRIPTION
Just use the local memory cache for now.

Fly.io has started charging to use Redis on their platform and it no longer has a free tier. We barely use caching just just cache some recent videos and meetups so we don't keep hitting the Youtube/Meetup APIs and to make things faster for repeat visitors.

Ref: https://github.com/sandiegopython/pythonsd-django/issues/172