### PR TITLE
Remove JFrog as a sponsor

### DIFF
--- a/pythonsd/templates/pythonsd/index.html
+++ b/pythonsd/templates/pythonsd/index.html
@@ -62,14 +62,6 @@
           </figcaption>
         </figure>
 
-        <figure class="flex items-center space-x-4">
-          <img src="{% static 'img/sponsors/jfrog-logo.png' %}" class="flex-none h-16" alt="JFrog">
-          <figcaption class="flex-auto">
-            <h5 class="mt-0 mb-1"><a href="https://jfrog.com/" rel="nofollow noopener noreferrer">JFrog</a></h5>
-            <p class="m-0">JFrog sponsors our monthly meetups and provides giveaways!</p>
-          </figcaption>
-        </figure>
-
         <p class="text-sm">You can <a href="https://psfmember.org/civicrm/contribute/transact/?reset=1&id=9">donate to San Diego Python</a> through the PSF. Your donation may be tax deductible. All donations go toward events, workshops, and training materials.</p>
 
       </div>


### PR DESCRIPTION
They are no longer sponsoring the meetup. We still list "past sponsors" on our meetup page. Perhaps we should have a section on the website for past sponsors.