### PR TITLE
Remove appveyor from testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This is the repository for the San Diego Python website at [sandiegopython.org](https://sandiegopython.org).
 
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/184l9lc8y7av2fah?svg=true)](https://ci.appveyor.com/project/davidfischer/pythonsd-django)
-
 
 ## Developing
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,0 @@
-install:
-  - "SET PATH=C:\\Python37;C:\\Python37\\Scripts;C:\\Program Files\\PostgreSQL\\9.4\\bin;%PATH%"
-  - "pip install --requirement requirements/local.txt"
-
-build: off
-
-test_script: coverage run manage.py test


### PR DESCRIPTION
Very old versions of the site were tested with Appveyor, a service that could test to make sure build steps ran on Windows. This isn't really necessary now that the site is Dockerized.

Appveyor hasn't run in over 4 years probably when we moved the organization from pythonsd -> sandiegopython.
I don't think anybody noticed which is a pretty strong indication it isn't needed.