### PR TITLE
Switch to using Meetup's GraphQL API

### DIFF
--- a/pythonsd/tests/data/meetup-events-api.json
+++ b/pythonsd/tests/data/meetup-events-api.json
@@ -1,146 +1,49 @@
-[
-  {
-    "status": "upcoming",
-    "local_date": "2019-10-12",
-    "how_to_find_us": "Parking is free on the weekends in the Hopkins parking structure. We will usually be near Audrey's Cafe. Turn right after entering the library and look near the cafe first, or check the comments below for the table location.",
-    "group": {
-      "who": "Python Developers",
-      "name": "San Diego Python Users Group",
-      "join_mode": "open",
-      "country": "us",
-      "region": "en_US",
-      "created": 1326433663000,
-      "lon": -117.19999694824219,
-      "state": "CA",
-      "localized_location": "San Diego, CA",
-      "timezone": "US/Pacific",
-      "lat": 32.7599983215332,
-      "urlname": "pythonsd",
-      "id": 3096872
-    },
-    "name": "Saturday Study Group",
-    "created": 1544308522000,
-    "member_pay_fee": false,
-    "venue": {
-      "city": "San Diego",
-      "name": "UCSD Geisel Library",
-      "zip": "",
-      "repinned": true,
-      "lon": -117.23896026611328,
-      "localized_country_name": "USA",
-      "state": "CA",
-      "address_1": "Hopkins Parking Structure",
-      "country": "us",
-      "lat": 32.883792877197266,
-      "id": 24990930
-    },
-    "updated": 1544308522000,
-    "visibility": "public",
-    "date_in_series_pattern": false,
-    "yes_rsvp_count": 7,
-    "utc_offset": -25200000,
-    "local_time": "12:00",
-    "time": 1570906800000,
-    "duration": 10800000,
-    "waitlist_count": 0,
-    "id": "fdzbnqyznbqb",
-    "link": "https://www.meetup.com/pythonsd/events/fdzbnqyznbqb/",
-    "description": "<p>Every Saturday we meet up with the larger Python community (including San Diego PyLadies (<a href=\"http://www.meetup.com/sd-pyladies\" class=\"linkified\">http://www.meetup.com/sd-pyladies</a>), Open BioInformatics San Diego (<a href=\"https://www.meetup.com/Open-Bioinformatics-SanDiego/\" class=\"linkified\">https://www.meetup.com/Open-Bioinformatics-SanDiego/</a>) and San Diego Artificial Intelligence (<a href=\"https://www.meetup.com/SanDiegoAI/\" class=\"linkified\">https://www.meetup.com/SanDiegoAI/</a>)) to chat, learn, and hang out. Our study group is for everyone on their Python journey, whether you're just starting out, an experienced pro, or anywhere in between.</p> <p>There's no formal instruction, just a bunch of folks who like to code. (If you're new to Python, check out these handy resources (<a href=\"http://pythonsd.org/pages/getting-started.html\" class=\"linkified\">http://pythonsd.org/pages/getting-started.html</a>)!)</p> <p>We have a great time, come join us! Bring your laptop and any questions you have about Python. Free feel to show up at any time and stay as long as you want. Hope to see you there!</p> <p>Python Community Code of Conduct (<a href=\"http://www.pythonsd.org/pages/code-of-conduct.html\" class=\"linkified\">http://www.pythonsd.org/pages/code-of-conduct.html</a>): Python is much more than a software language. Python is a vibrant community made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. Overall, we're good to each other. We contribute to this community not because we have to, but because we want to.</p> "
-  },
-  {
-    "status": "upcoming",
-    "local_date": "2019-10-19",
-    "how_to_find_us": "Parking is free on the weekends in the Hopkins parking structure. We will usually be near Audrey's Cafe. Turn right after entering the library and look near the cafe first, or check the comments below for the table location.",
-    "group": {
-      "who": "Python Developers",
-      "name": "San Diego Python Users Group",
-      "join_mode": "open",
-      "country": "us",
-      "region": "en_US",
-      "created": 1326433663000,
-      "lon": -117.19999694824219,
-      "state": "CA",
-      "localized_location": "San Diego, CA",
-      "timezone": "US/Pacific",
-      "lat": 32.7599983215332,
-      "urlname": "pythonsd",
-      "id": 3096872
-    },
-    "name": "Saturday Study Group",
-    "created": 1544308522000,
-    "member_pay_fee": false,
-    "venue": {
-      "city": "San Diego",
-      "name": "UCSD Geisel Library",
-      "zip": "",
-      "repinned": true,
-      "lon": -117.23896026611328,
-      "localized_country_name": "USA",
-      "state": "CA",
-      "address_1": "Hopkins Parking Structure",
-      "country": "us",
-      "lat": 32.883792877197266,
-      "id": 24990930
-    },
-    "updated": 1544308522000,
-    "visibility": "public",
-    "date_in_series_pattern": false,
-    "yes_rsvp_count": 7,
-    "utc_offset": -25200000,
-    "local_time": "12:00",
-    "time": 1571511600000,
-    "duration": 10800000,
-    "waitlist_count": 0,
-    "id": "fdzbnqyznbzb",
-    "link": "https://www.meetup.com/pythonsd/events/fdzbnqyznbzb/",
-    "description": "<p>Every Saturday we meet up with the larger Python community (including San Diego PyLadies (<a href=\"http://www.meetup.com/sd-pyladies\" class=\"linkified\">http://www.meetup.com/sd-pyladies</a>), Open BioInformatics San Diego (<a href=\"https://www.meetup.com/Open-Bioinformatics-SanDiego/\" class=\"linkified\">https://www.meetup.com/Open-Bioinformatics-SanDiego/</a>) and San Diego Artificial Intelligence (<a href=\"https://www.meetup.com/SanDiegoAI/\" class=\"linkified\">https://www.meetup.com/SanDiegoAI/</a>)) to chat, learn, and hang out. Our study group is for everyone on their Python journey, whether you're just starting out, an experienced pro, or anywhere in between.</p> <p>There's no formal instruction, just a bunch of folks who like to code. (If you're new to Python, check out these handy resources (<a href=\"http://pythonsd.org/pages/getting-started.html\" class=\"linkified\">http://pythonsd.org/pages/getting-started.html</a>)!)</p> <p>We have a great time, come join us! Bring your laptop and any questions you have about Python. Free feel to show up at any time and stay as long as you want. Hope to see you there!</p> <p>Python Community Code of Conduct (<a href=\"http://www.pythonsd.org/pages/code-of-conduct.html\" class=\"linkified\">http://www.pythonsd.org/pages/code-of-conduct.html</a>): Python is much more than a software language. Python is a vibrant community made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. Overall, we're good to each other. We contribute to this community not because we have to, but because we want to.</p> "
-  },
-  {
-    "status": "upcoming",
-    "local_date": "2019-10-24",
-    "how_to_find_us": "We are in the auditorium which is straight back through the cafeteria on the first floor. The doors are locked at 7:15 but there should be a sign posted with number to call to be let in.",
-    "group": {
-      "who": "Python Developers",
-      "name": "San Diego Python Users Group",
-      "join_mode": "open",
-      "country": "us",
-      "region": "en_US",
-      "created": 1326433663000,
-      "lon": -117.19999694824219,
-      "state": "CA",
-      "localized_location": "San Diego, CA",
-      "timezone": "US/Pacific",
-      "lat": 32.7599983215332,
-      "urlname": "pythonsd",
-      "id": 3096872
-    },
-    "name": "Monthly Meetup",
-    "created": 1556902700000,
-    "member_pay_fee": false,
-    "venue": {
-      "city": "San Diego",
-      "name": "Qualcomm Building Q",
-      "zip": "92121",
-      "repinned": false,
-      "lon": -117.20123291015625,
-      "localized_country_name": "USA",
-      "state": "CA",
-      "address_1": "6455 Lusk Blvd",
-      "country": "us",
-      "lat": 32.90226745605469,
-      "id": 26335029
-    },
-    "updated": 1556902700000,
-    "visibility": "public",
-    "date_in_series_pattern": false,
-    "yes_rsvp_count": 10,
-    "utc_offset": -25200000,
-    "local_time": "19:00",
-    "time": 1571968800000,
-    "duration": 7200000,
-    "waitlist_count": 0,
-    "id": "zgtnxqyznbgc",
-    "link": "https://www.meetup.com/pythonsd/events/zgtnxqyznbgc/",
-    "description": "<p>Thanks to The Qualcomm Learning Center for hosting! This meetup will be in Qualcomm's Building Q auditorium. Cloudflare's Developer Relations will provide pizza!</p> <p>AGENDA</p> <p>We will be doing 5-7 minute lightning talks If you are interested in giving a talk, please post in the comments or get in touch with Diane (<a href=\"https://www.meetup.com/pythonsd/members/9220987/\" class=\"linkified\">https://www.meetup.com/pythonsd/members/9220987/</a>).</p> <p>Currently Scheduled talks:</p> <p>ANNOUNCEMENTS</p> <p>We want your feedback improving San Diego Python! Post it here (<a href=\"https://goo.gl/forms/NmfGY4ReTTPms9cw1\" class=\"linkified\">https://goo.gl/forms/NmfGY4ReTTPms9cw1</a>).</p> <p>San Diego Python has a code of conduct (<a href=\"http://www.pythonsd.org/pages/code-of-conduct.html\" class=\"linkified\">http://www.pythonsd.org/pages/code-of-conduct.html</a>).</p> "
+{
+  "data": {
+    "groupByUrlname": {
+      "events": {
+        "edges": [
+          {
+            "node": {
+              "id": "305930677",
+              "title": "SDPy Monthly Meetup",
+              "eventUrl": "https://www.meetup.com/pythonsd/events/305930677/",
+              "venues": [
+                {
+                  "name": "Qualcomm Building Q"
+                }
+              ],
+              "dateTime": "2025-05-22T19:00:00-07:00"
+            }
+          },
+          {
+            "node": {
+              "id": "305930676",
+              "title": "SDPy Monthly Meetup",
+              "eventUrl": "https://www.meetup.com/pythonsd/events/305930676/",
+              "venues": [
+                {
+                  "name": "Qualcomm Building Q"
+                }
+              ],
+              "dateTime": "2025-06-26T19:00:00-07:00"
+            }
+          },
+          {
+            "node": {
+              "id": "305930675",
+              "title": "SDPy Monthly Meetup",
+              "eventUrl": "https://www.meetup.com/pythonsd/events/305930675/",
+              "venues": [
+                {
+                  "name": "Qualcomm Building Q"
+                }
+              ],
+              "dateTime": "2025-07-24T19:00:00-07:00"
+            }
+          }
+        ]
+      }
+    }
   }
-]
+}


### PR DESCRIPTION
Meetup.com has a new GraphQL API to replace their REST API that we were previously using to display upcoming events on our website. Meetup's documentation and landing pages seem to point to this new API requiring a Meetup.com PRO subscription (paid). We were able to get an API key as part of the Python Software Foundation's "Meetup Pro Network". However, in testing, I was able to query the API without authenticating whatsoever.

Just a few notes:

- Meetup's documentation does not appear to be 100% accurate. I found a few fields in their field reference that were not correct.
- The [API Playground](https://www.meetup.com/api/playground/) does appear to be accurate and is very helpful for testing the API.
- I found that I did not need an API key simply for simple querying. Their authorization is using OAuth and most of the use cases are for authorizing attendees rather than simply querying data from Meetup.

Ref: https://github.com/sandiegopython/pythonsd-django/issues/182