### PR TITLE
Upgrades to Python and Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-ARG PYTHON_VERSION=3.10-slim-buster
+# https://www.debian.org/releases/stable/
+# https://hub.docker.com/_/python/
+ARG PYTHON_VERSION=3.13-slim-bookworm
 
 FROM python:${PYTHON_VERSION}
 
@@ -20,7 +22,7 @@ RUN apt-get install -y --no-install-recommends \
     make \
     build-essential \
     g++ \
-    postgresql-client \
+    postgresql-client libpq-dev \
     git
 
 RUN mkdir -p /code

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -21,4 +21,4 @@ django-enforce-host==1.1.0
 defusedxml==0.7.1
 
 # Used for image field handling
-pillow==10.3.0
+pillow==11.3.0

--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -1,7 +1,8 @@
 -r common.txt
 
 # Database server
-psycopg2-binary==2.9.9
+# https://www.psycopg.org/docs/install.html#install-from-source
+psycopg2==2.9.10
 
 # Email
 django-anymail==10.3


### PR DESCRIPTION
Debian Buster has exited LTS and the deploy was failing. While upgrading Python, Pillow and Postgres required some updates to continue building successfully.