### PR TITLE
Upgrade to Python 3.14

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,10 @@
 [run]
-branch: True
+branch = True
+# Currently, Python3.14 defaults to sysmon which is incompatible with coverage plugins
+# https://coverage.readthedocs.io/en/7.11.0/config.html#run-core
+# https://github.com/nedbat/coveragepy/issues/1790
+# https://github.com/nedbat/django_coverage_plugin/issues/102
+core = ctrace
 source =
   config
   pythonsd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.14"
 
       - name: Run CI
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,4 +12,4 @@ repos:
       # Since the pre-commit runs on a file by file basis rather than a whole project,
       # The excludes in pyproject.toml are ignored
       exclude: migrations
-      language_version: python3.10
+      language_version: python3.14

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v6.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 25.9.0
     hooks:
     - id: black
       # Since the pre-commit runs on a file by file basis rather than a whole project,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # https://www.debian.org/releases/stable/
 # https://hub.docker.com/_/python/
-ARG PYTHON_VERSION=3.13-slim-bookworm
+ARG PYTHON_VERSION=3.14-slim-trixie
 
 FROM python:${PYTHON_VERSION}
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the repository for the San Diego Python website at [sandiegopython.org](
 
 ### Prerequisites
 
-* Python v3.10
+* Python v3.14
 * Node v20
 
 ### Getting started

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -2,10 +2,10 @@
 Django settings for pythonsd project.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/4.2/topics/settings/
+https://docs.djangoproject.com/en/dev/topics/settings/
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/4.2/ref/settings/
+https://docs.djangoproject.com/en/dev/ref/settings/
 """
 
 import json
@@ -20,7 +20,7 @@ ADMIN_URL = "admin"
 
 
 # Quick-start development settings - unsuitable for production
-# https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
+# https://docs.djangoproject.com/en/dev/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 # SECURITY WARNING: don't run with debug turned on in production!
@@ -82,14 +82,14 @@ WSGI_APPLICATION = "config.wsgi.application"
 
 
 # Database
-# https://docs.djangoproject.com/en/4.2/ref/settings/#databases
+# https://docs.djangoproject.com/en/dev/ref/settings/#databases
 # --------------------------------------------------------------------------
 DATABASES = {"default": dj_database_url.config(default="sqlite:///db.sqlite3")}
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 
 # Internationalization
-# https://docs.djangoproject.com/en/4.2/topics/i18n/
+# https://docs.djangoproject.com/en/dev/topics/i18n/
 # --------------------------------------------------------------------------
 LANGUAGE_CODE = "en-us"
 
@@ -101,8 +101,8 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/4.2/howto/static-files/
-# https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-STORAGES
+# https://docs.djangoproject.com/en/dev/howto/static-files/
+# https://docs.djangoproject.com/en/dev/ref/settings/#std-setting-STORAGES
 # --------------------------------------------------------------------------
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 STATIC_URL = "/static-files/"
@@ -127,7 +127,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 
 # Email
-# https://docs.djangoproject.com/en/4.2/topics/email/
+# https://docs.djangoproject.com/en/dev/topics/email/
 # --------------------------------------------------------------------------
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 DEFAULT_FROM_EMAIL = "noreply@sandiegopython.org"
@@ -135,7 +135,7 @@ SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 
 # Caching
-# https://docs.djangoproject.com/en/4.2/ref/settings/#caches
+# https://docs.djangoproject.com/en/dev/ref/settings/#caches
 # --------------------------------------------------------------------------
 CACHES = {
     "default": {
@@ -148,8 +148,8 @@ CACHES = {
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
 # the site admins on every HTTP 500 error when DEBUG=False.
-# http://docs.djangoproject.com/en/4.2/topics/logging
-# https://docs.djangoproject.com/en/4.2/ref/settings/#logging
+# http://docs.djangoproject.com/en/dev/topics/logging
+# https://docs.djangoproject.com/en/dev/ref/settings/#logging
 # --------------------------------------------------------------------------
 LOGGING = {
     "version": 1,

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -12,7 +12,7 @@ import dj_database_url
 from .base import *  # noqa
 
 
-# See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/dev/howto/deployment/checklist/
 
 DEBUG = False
 SECRET_KEY = os.environ["SECRET_KEY"]
@@ -51,7 +51,7 @@ if AWS_S3_ACCESS_KEY_ID and AWS_S3_SECRET_ACCESS_KEY and AWS_STORAGE_BUCKET_NAME
 
 
 # Database
-# https://docs.djangoproject.com/en/4.2/ref/settings/#databases
+# https://docs.djangoproject.com/en/dev/ref/settings/#databases
 # --------------------------------------------------------------------------
 DATABASES = {"default": dj_database_url.config()}
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
@@ -59,7 +59,7 @@ DATABASES["default"]["CONN_MAX_AGE"] = 600
 
 
 # Security
-# https://docs.djangoproject.com/en/4.2/topics/security/
+# https://docs.djangoproject.com/en/dev/topics/security/
 # --------------------------------------------------------------------------
 if "SECURE_SSL_HOST" in os.environ:
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
@@ -82,14 +82,14 @@ ENFORCE_HOST = os.environ.get("ENFORCE_HOST", None)
 
 
 # Sessions
-# https://docs.djangoproject.com/en/4.2/topics/http/sessions/
+# https://docs.djangoproject.com/en/dev/topics/http/sessions/
 # Don't put sessions in the database
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 
 
 # Email
-# https://docs.djangoproject.com/en/4.2/topics/email/
+# https://docs.djangoproject.com/en/dev/topics/email/
 # https://anymail.readthedocs.io/en/stable/
 # --------------------------------------------------------------------------
 if "SENDGRID_API_KEY" in os.environ:
@@ -99,7 +99,7 @@ if "SENDGRID_API_KEY" in os.environ:
 
 
 # Logging
-# http://docs.djangoproject.com/en/4.2/topics/logging
+# http://docs.djangoproject.com/en/dev/topics/logging
 # --------------------------------------------------------------------------
 LOGGING["loggers"][""]["level"] = "INFO"
 LOGGING["loggers"]["pythonsd"]["level"] = "INFO"

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for pythonsd project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/dev/howto/deployment/wsgi/
 """
 
 import os

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,18 +1,18 @@
 # Helper for transforming a database URL envvar
 # to a Django connection string
-dj-database-url==2.2.0
+dj-database-url==3.0.1
 
 # This is a Django app
-Django==4.2.25
+Django==5.2.7
 
 # A zero dependency WSGI server
 gunicorn==23.0.0
 
 # For connecting to various APIs (eg. Meetup.com)
-requests==2.32.4
+requests==2.32.5
 
 # For serving static assets from the WSGI server
-whitenoise==6.5.0
+whitenoise==6.11.0
 
 # Redirects requests to other hosts to this one
 django-enforce-host==1.1.0
@@ -21,4 +21,4 @@ django-enforce-host==1.1.0
 defusedxml==0.7.1
 
 # Used for image field handling
-pillow==11.3.0
+pillow==12.0.0

--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -2,10 +2,10 @@
 
 # Database server
 # https://www.psycopg.org/docs/install.html#install-from-source
-psycopg2==2.9.10
+psycopg[binary]==3.2.12
 
 # Email
-django-anymail==10.3
+django-anymail==13.1
 
 # Cloud storage for media storage (S3, R2, etc.)
-django-storages[s3]==1.14.3
+django-storages[s3]==1.14.6

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,20 +1,20 @@
 -r common.txt
 
 # Used for code formatting
-black==24.4.2
-pre-commit==3.7.1
+black==25.9.0
+pre-commit==4.3.0
 
 # Used for code coverage
-coverage==7.5.1
-django_coverage_plugin==3.1.0
+coverage==7.11.0
+django_coverage_plugin==3.2.0
 
 # Used in local testing
-WebTest==3.0.0
-beautifulsoup4==4.12.3
+WebTest==3.0.7
+beautifulsoup4==4.14.2
 WebOb==1.8.9
-responses==0.25.0
+responses==0.25.8
 
 # Used to help with Django related debugging
-django-debug-toolbar==4.3.0
+django-debug-toolbar==6.0.0
 
 tox>=4.0,<5.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -11,7 +11,7 @@ django_coverage_plugin==3.1.0
 # Used in local testing
 WebTest==3.0.0
 beautifulsoup4==4.12.3
-WebOb==1.8.8
+WebOb==1.8.9
 responses==0.25.0
 
 # Used to help with Django related debugging


### PR DESCRIPTION
- Run CI tests on 3.14
- Run production instance on 3.14
- Code checkers should validate against 3.14 styles
- WebOb needs a new version due to "cgi" module removal